### PR TITLE
Drop CLOCK_MONOTONIC_RAW

### DIFF
--- a/sz/src/sz_omp.c
+++ b/sz/src/sz_omp.c
@@ -16,7 +16,7 @@ double sz_wtime(){
     return omp_get_wtime();
 #else
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
 
     return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
 #endif


### PR DESCRIPTION
This is Linux-specific: https://www.man7.org/linux/man-pages/man2/clock_gettime.2.html

It fixes compilation on mingw, see #58