### PR TITLE
Fix cmake to no longer depend on FFTW3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ option(BUILD_SHARED_LIBS "build shared libraries over static libraries" ON)
 #find dependencies
 include(GNUInstallDirs)
 find_package(PkgConfig)
-pkg_search_module(FFTW3 IMPORTED_TARGET fftw3)
 pkg_search_module(ZSTD  IMPORTED_TARGET libzstd)
 
 #by default pass no 3rd party exports

--- a/sz/CMakeLists.txt
+++ b/sz/CMakeLists.txt
@@ -70,11 +70,6 @@ target_compile_options(SZ
 	PRIVATE $<$<CONFIG:Debug>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
 	)
 
-if(FFTW3_FOUND)
-  target_compile_definitions(SZ PUBLIC FFTW3)
-  target_link_libraries(SZ PUBLIC PkgConfig::FFTW3)
-endif()
-
 if(BUILD_PASTRI)
   target_compile_definitions(SZ PUBLIC HAVE_PASTRI)
 endif()


### PR DESCRIPTION
Previous versions of SZ were documented as using FFTW, but as far as I
can find, we aren't using it anywhere, and the references have been
removed from the auto-tools config files so removing remaining
references.