### PR TITLE
fix compilation errors for SZ python bindings

### DIFF
--- a/swig/pysz.h
+++ b/swig/pysz.h
@@ -87,9 +87,13 @@ class ExaFELConfigBuilder {
   public:
   exafelSZ_params* build() { 
     exafelSZ_params* params = new exafelSZ_params;
-    params->peaks = new uint8_t [peaks.size()];
+    params->peaksSegs = new uint16_t [peaks.size()];
+    params->peaksRows = new uint16_t [peaks.size()];
+    params->peaksCols = new uint16_t [peaks.size()];
     params->calibPanel = new uint8_t [calibPanel.size()];
-    std::copy(std::begin(peaks), std::end(peaks), params->peaks);
+    std::copy(std::begin(peaks), std::end(peaks), params->peaksSegs);
+    std::copy(std::begin(peakRows), std::end(peakRows), params->peaksRows);
+    std::copy(std::begin(peakCols), std::end(peakCols), params->peaksCols);
     std::copy(std::begin(calibPanel), std::end(calibPanel), params->calibPanel);
     params->binSize = binSize;
     params->tolerance = tolerance;
@@ -105,20 +109,30 @@ class ExaFELConfigBuilder {
 
 
   static void free(exafelSZ_params* params) {
-    delete[] params->peaks;
+    delete[] params->peaksSegs;
+    delete[] params->peaksRows;
+    delete[] params->peaksCols;
     delete[] params->calibPanel;
     delete params;
   }
 
-  void setPeaks(std::vector<uint8_t> const& peaks) {
+  void setPeaks(std::vector<uint16_t> const& peaks) {
     this->peaks = peaks;
+  }
+  void setPeaksRows(std::vector<uint16_t> const& rows) {
+    this->peakRows = rows;
+  }
+  void setPeaksCols(std::vector<uint16_t> const& cols) {
+    this->peakCols = cols;
   }
   void setCalibPanel(std::vector<uint8_t> const& calibPanel) {
     this->calibPanel = calibPanel;
   }
 
   private:
-  std::vector<uint8_t> peaks;
+  std::vector<uint16_t> peaks;
+  std::vector<uint16_t> peakRows;
+  std::vector<uint16_t> peakCols;
   std::vector<uint8_t> calibPanel;
 };
 


### PR DESCRIPTION
@disheng222 we don't need to do a new release for this, but if someone wants to build the python bindings, I'd rather them no fail to compile.  This bug was introduced when Ali updated the SZ-Exafel compressor code.

In the long run, I would like to deprecate and remove the SZ Python bindings in favor of the LibPressio python bindings for SZ which are higher performance, easier to maintain, more feature-ful, and more robust to user error, but I didn't want to just remove the old SZ python bindings without warning.