### PR TITLE
Point users to LibPressio python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ add_subdirectory(example)
 
 option(BUILD_PYTHON_WRAPPER "build python wrapper" OFF)
 if(BUILD_PYTHON_WRAPPER)
+  message(WARNING "The python bindings for SZ are deprecated.  "
+                  "Please consider using the Python bindings for "
+                  "[LibPressio](https://github.com/codarcode/libpressio#python)"
+                  " to use SZ from python instead.")
   add_subdirectory(swig)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Please see doc/use-guide for details
 
 ### Python Interface
 
+**NOTE: THESE BINDINGS ARE DEPRECATED **
+
+The following information is provided for historical purposes only.
+Please consider updating to using the Python bindings for SZ provided with [LibPressio](https://github.com/codarcode/libpressio#python) instead which are more efficient and updated with new features in SZ as they are developed.
+
 The python bindings requires some additional dependencies:
 
 - python with development libraries


### PR DESCRIPTION
The SZ python bindings are deprecated, please consider using the
libpressio python bindings instead which are much more efficient and
easy to update and safely use.