### PR TITLE
Fix SZ threadsafe

### DIFF
--- a/sz/src/sz.c
+++ b/sz/src/sz.c
@@ -1242,7 +1242,6 @@ unsigned char* SZ_compress_customize_threadsafe(const char* cmprName, void* user
 	unsigned char* result = NULL;
 	if(strcmp(cmprName, "SZ2.0")==0 || strcmp(cmprName, "SZ2.1")==0 || strcmp(cmprName, "SZ")==0)
 	{
-		SZ_Init(NULL);
 		struct sz_params* para = (struct sz_params*)userPara;
 		
 		if(dataType==SZ_FLOAT)


### PR DESCRIPTION
Calling SZ_Init in SZ_compress_customize_threadsafe can cause different threads to race when attempting to set confparams_cpr->maxRangeRadius and other parameters on this structure.  Since SZ_Init zero initalizes the structure before filling it with the default value, there is a brief window where another executing SZ compression thread reads the 0 and segfaults or throws a SIGFPE.  This change requires SZ_threadsafe users to call SZ Init before using this interface.