### PR TITLE
bump revision number to allow testing for new write stat

### DIFF
--- a/sz/include/defines.h
+++ b/sz/include/defines.h
@@ -14,7 +14,7 @@
 #define SZ_VER_MAJOR 2
 #define SZ_VER_MINOR 1
 #define SZ_VER_BUILD 12
-#define SZ_VER_REVISION 1
+#define SZ_VER_REVISION 2
 
 #define PASTRI 103
 #define HZ 102 //deprecated


### PR DESCRIPTION
@disheng222 Could we bump the version number so I can detect the new constant_flag member of write_stats in LibPressio?