### PR TITLE
Introduce ability to track quantization intervals

### DIFF
--- a/sz/include/defines.h
+++ b/sz/include/defines.h
@@ -14,7 +14,7 @@
 #define SZ_VER_MAJOR 2
 #define SZ_VER_MINOR 1
 #define SZ_VER_BUILD 12
-#define SZ_VER_REVISION 2
+#define SZ_VER_REVISION 3
 
 #define PASTRI 103
 #define HZ 102 //deprecated

--- a/sz/include/sz_stats.h
+++ b/sz/include/sz_stats.h
@@ -40,7 +40,8 @@ typedef struct sz_stats
 	float unpredictPercent;
 	
 	float zstdCompressionRatio; //not available yet
-	
+
+  unsigned int quantization_intervals;
 } sz_stats;
 
 extern sz_stats sz_stat;
@@ -51,6 +52,7 @@ void writeHuffmanInfo(size_t huffmanTreeSize, size_t huffmanCodingSize, size_t t
 void writeZstdCompressionRatio(float zstdCompressionRatio);
 void writeConstantFlag(int flag);
 void writeUnpredictDataCounts(size_t unpredictCount, size_t totalNumElements);
+void writeQuantizationInfo(unsigned int quantization_intervals);
 void printSZStats();
 
 #ifdef __cplusplus

--- a/sz/src/sz_double.c
+++ b/sz/src/sz_double.c
@@ -5738,6 +5738,7 @@ unsigned char * SZ_compress_double_2D_MDQ_nonblocked_with_blocked_regression(dou
 	writeHuffmanInfo(treeByteSize, typeArray_size, num_elements*sizeof(float), nodeCount);
 	writeBlockInfo(use_mean, block_size, reg_count, num_blocks);
 	writeUnpredictDataCounts(total_unpred, num_elements);
+  writeQuantizationInfo(quantization_intervals);
 #endif
 
 	size_t totalEncodeSize = result_pos - result;
@@ -6838,6 +6839,7 @@ unsigned char * SZ_compress_double_3D_MDQ_nonblocked_with_blocked_regression(dou
 	writeHuffmanInfo(treeByteSize, typeArray_size, num_elements*sizeof(float), nodeCount);
 	writeBlockInfo(use_mean, block_size, reg_count, num_blocks);
 	writeUnpredictDataCounts(total_unpred, num_elements);
+  writeQuantizationInfo(quantization_intervals);
 #endif
 
 	SZ_ReleaseHuffman(huffmanTree);

--- a/sz/src/sz_float.c
+++ b/sz/src/sz_float.c
@@ -6361,6 +6361,7 @@ unsigned char * SZ_compress_float_2D_MDQ_nonblocked_with_blocked_regression(floa
 	writeHuffmanInfo(treeByteSize, typeArray_size, num_elements*sizeof(float), nodeCount);
 	writeBlockInfo(use_mean, block_size, reg_count, num_blocks);
 	writeUnpredictDataCounts(total_unpred, num_elements);
+	writeQuantizationInfo(quantization_intervals);
 #endif
 
 	size_t totalEncodeSize = result_pos - result;
@@ -7464,6 +7465,7 @@ unsigned char * SZ_compress_float_3D_MDQ_nonblocked_with_blocked_regression(floa
 	writeHuffmanInfo(treeByteSize, typeArray_size, num_elements*sizeof(float), nodeCount);
 	writeBlockInfo(use_mean, block_size, reg_count, num_blocks);
 	writeUnpredictDataCounts(total_unpred, num_elements);
+	writeQuantizationInfo(quantization_intervals);
 #endif
 
 	SZ_ReleaseHuffman(huffmanTree);

--- a/sz/src/sz_stats.c
+++ b/sz/src/sz_stats.c
@@ -1,6 +1,6 @@
 #include <sz_stats.h>
 
-sz_stats sz_stat;
+sz_stats sz_stat = {0};
 
 void writeBlockInfo(int use_mean, size_t blockSize, size_t regressionBlocks, size_t totalBlocks)
 {
@@ -29,6 +29,10 @@ void writeZstdCompressionRatio(float zstdCompressionRatio)
 void writeConstantFlag(int flag)
 {
 	sz_stat.constant_flag = flag;
+}
+
+void writeQuantizationInfo(unsigned int intervals) {
+  sz_stat.quantization_intervals = intervals;
 }
 
 void writeUnpredictDataCounts(size_t unpredictCount, size_t totalNumElements)
@@ -65,4 +69,6 @@ void printSZStats()
 
 	printf("unpredictCount             %zu\n", sz_stat.unpredictCount);
 	printf("unpredictPercent           %f\n", sz_stat.unpredictPercent);
+
+	printf("quantization_intervals     %u\n", sz_stat.quantization_intervals);
 }


### PR DESCRIPTION
Previous versions of SZ would report the number of quantization intervals
selected.  This patch restores that ability when compiled with
BUILD_STATS.