### PR TITLE
Make the code compile under windows with native Microsoft compilers.

### DIFF
--- a/sz/src/Huffman.c
+++ b/sz/src/Huffman.c
@@ -362,7 +362,7 @@ void decode_MSST19(unsigned char *s, size_t targetLength, node t, int *out, int 
     int* valueTable = (int*)malloc(tableSize * sizeof(int));
     uint8_t* lengthTable = (uint8_t*)malloc(tableSize * sizeof(int));
     node* nodeTable = (node*)malloc(tableSize * sizeof(node));
-    uint32_t maskTable[maxBits+8];
+    uint32_t* maskTable = (uint32_t*) malloc((maxBits+8) * sizeof(uint32_t));
     int j;
     for(uint32_t i=0; i<tableSize; i++){
         n = t;
@@ -437,6 +437,7 @@ void decode_MSST19(unsigned char *s, size_t targetLength, node t, int *out, int 
     free(valueTable);
     free(lengthTable);
     free(nodeTable);
+    free(maskTable);
 	return;
 }
 void pad_tree_uchar(HuffmanTree* huffmanTree, unsigned char* L, unsigned char* R, unsigned int* C, unsigned char* t, unsigned int i, node root)

--- a/sz/src/TypeManager.c
+++ b/sz/src/TypeManager.c
@@ -17,12 +17,12 @@
 size_t convertIntArray2ByteArray_fast_1b(unsigned char* intArray, size_t intArrayLength, unsigned char **result)
 {
 	size_t byteLength = 0;
-	size_t i, j; 
+	size_t i, j;
 	if(intArrayLength%8==0)
 		byteLength = intArrayLength/8;
 	else
 		byteLength = intArrayLength/8+1;
-		
+
 	if(byteLength>0)
 		*result = (unsigned char*)malloc(byteLength*sizeof(unsigned char));
 	else
@@ -47,12 +47,12 @@ size_t convertIntArray2ByteArray_fast_1b(unsigned char* intArray, size_t intArra
 size_t convertIntArray2ByteArray_fast_1b_to_result(unsigned char* intArray, size_t intArrayLength, unsigned char *result)
 {
 	size_t byteLength = 0;
-	size_t i, j; 
+	size_t i, j;
 	if(intArrayLength%8==0)
 		byteLength = intArrayLength/8;
 	else
 		byteLength = intArrayLength/8+1;
-		
+
 	size_t n = 0;
 	int tmp, type;
 	for(i = 0;i<byteLength;i++)
@@ -70,7 +70,7 @@ size_t convertIntArray2ByteArray_fast_1b_to_result(unsigned char* intArray, size
 	return byteLength;
 }
 
-void convertByteArray2IntArray_fast_1b(size_t intArrayLength, unsigned char* byteArray, size_t byteArrayLength, unsigned char **intArray)	
+void convertByteArray2IntArray_fast_1b(size_t intArrayLength, unsigned char* byteArray, size_t byteArrayLength, unsigned char **intArray)
 {
     if(intArrayLength > byteArrayLength*8)
     {
@@ -81,11 +81,11 @@ void convertByteArray2IntArray_fast_1b(size_t intArrayLength, unsigned char* byt
 	if(intArrayLength>0)
 		*intArray = (unsigned char*)malloc(intArrayLength*sizeof(unsigned char));
 	else
-		*intArray = NULL;    
-    
+		*intArray = NULL;
+
 	size_t n = 0, i;
 	int tmp;
-	for (i = 0; i < byteArrayLength-1; i++) 
+	for (i = 0; i < byteArrayLength-1; i++)
 	{
 		tmp = byteArray[i];
 		(*intArray)[n++] = (tmp & 0x80) >> 7;
@@ -95,34 +95,34 @@ void convertByteArray2IntArray_fast_1b(size_t intArrayLength, unsigned char* byt
 		(*intArray)[n++] = (tmp & 0x08) >> 3;
 		(*intArray)[n++] = (tmp & 0x04) >> 2;
 		(*intArray)[n++] = (tmp & 0x02) >> 1;
-		(*intArray)[n++] = (tmp & 0x01) >> 0;		
+		(*intArray)[n++] = (tmp & 0x01) >> 0;
 	}
-	
-	tmp = byteArray[i];	
+
+	tmp = byteArray[i];
 	if(n == intArrayLength)
 		return;
 	(*intArray)[n++] = (tmp & 0x80) >> 7;
 	if(n == intArrayLength)
-		return;	
+		return;
 	(*intArray)[n++] = (tmp & 0x40) >> 6;
 	if(n == intArrayLength)
-		return;	
+		return;
 	(*intArray)[n++] = (tmp & 0x20) >> 5;
 	if(n == intArrayLength)
 		return;
 	(*intArray)[n++] = (tmp & 0x10) >> 4;
 	if(n == intArrayLength)
-		return;	
+		return;
 	(*intArray)[n++] = (tmp & 0x08) >> 3;
 	if(n == intArrayLength)
-		return;	
+		return;
 	(*intArray)[n++] = (tmp & 0x04) >> 2;
 	if(n == intArrayLength)
-		return;	
+		return;
 	(*intArray)[n++] = (tmp & 0x02) >> 1;
 	if(n == intArrayLength)
-		return;	
-	(*intArray)[n++] = (tmp & 0x01) >> 0;		
+		return;
+	(*intArray)[n++] = (tmp & 0x01) >> 0;
 }
 
 /**
@@ -151,8 +151,8 @@ size_t convertIntArray2ByteArray_fast_2b(unsigned char* timeStepType, size_t tim
 			int type = timeStepType[n];
 			switch(type)
 			{
-			case 0: 
-				
+			case 0:
+
 				break;
 			case 1:
 				tmp = (tmp | (1 << (6-j*2)));
@@ -191,8 +191,8 @@ size_t convertIntArray2ByteArray_fast_2b_inplace(unsigned char* timeStepType, si
 			int type = timeStepType[n];
 			switch(type)
 			{
-			case 0: 
-				
+			case 0:
+
 				break;
 			case 1:
 				tmp = (tmp | (1 << (6-j*2)));
@@ -252,7 +252,7 @@ void convertByteArray2IntArray_fast_2b(size_t stepLength, unsigned char* byteArr
 }
 
 size_t convertIntArray2ByteArray_fast_3b(unsigned char* timeStepType, size_t timeStepTypeLength, unsigned char **result)
-{	
+{
 	size_t i = 0, k = 0, byteLength = 0, n = 0;
 	if(timeStepTypeLength%8==0)
 		byteLength = timeStepTypeLength*3/8;
@@ -275,7 +275,7 @@ size_t convertIntArray2ByteArray_fast_3b(unsigned char* timeStepType, size_t tim
 		case 1:
 			tmp = tmp | (timeStepType[n] << 2);
 			break;
-		case 2: 
+		case 2:
 			tmp = tmp | (timeStepType[n] >> 1);
 			(*result)[i++] = (unsigned char)tmp;
 			tmp = 0 | (timeStepType[n] << 7);
@@ -303,24 +303,24 @@ size_t convertIntArray2ByteArray_fast_3b(unsigned char* timeStepType, size_t tim
 	}
 	if(k!=7) //load the last one
 		(*result)[i] = (unsigned char)tmp;
-	
+
 	return byteLength;
 }
 
 void convertByteArray2IntArray_fast_3b(size_t stepLength, unsigned char* byteArray, size_t byteArrayLength, unsigned char **intArray)
-{	
+{
 	if(stepLength > byteArrayLength*8/3)
 	{
 		printf("Error: stepLength > byteArray.length*8/3, impossible case unless bugs elsewhere.\n");
 		printf("stepLength=%zu, byteArray.length=%zu\n", stepLength, byteArrayLength);
-		exit(0);		
+		exit(0);
 	}
 	if(stepLength>0)
 		*intArray = (unsigned char*)malloc(stepLength*sizeof(unsigned char));
 	else
 		*intArray = NULL;
 	size_t i = 0, ii = 0, n = 0;
-	unsigned char tmp = byteArray[i];	
+	unsigned char tmp = byteArray[i];
 	for(n=0;n<stepLength;)
 	{
 		switch(n%8)
@@ -328,7 +328,7 @@ void convertByteArray2IntArray_fast_3b(size_t stepLength, unsigned char* byteArr
 		case 0:
 			(*intArray)[n++] = (tmp & 0xE0) >> 5;
 			break;
-		case 1: 
+		case 1:
 			(*intArray)[n++] = (tmp & 0x1C) >> 2;
 			break;
 		case 2:
@@ -351,7 +351,7 @@ void convertByteArray2IntArray_fast_3b(size_t stepLength, unsigned char* byteArr
 			ii |= (tmp & 0xC0) >> 6;
 			(*intArray)[n++] = ii;
 			break;
-		case 6: 
+		case 6:
 			(*intArray)[n++] = (tmp & 0x38) >> 3;
 			break;
 		case 7:
@@ -369,14 +369,14 @@ inline int getLeftMovingSteps(size_t k, unsigned char resiBitLength)
 }
 
 /**
- * 
+ *
  * @param timeStepType is the resiMidBits
  * @param resiBitLength is the length of resiMidBits for each element, (the number of resiBitLength == the # of unpredictable elements
  * @return
  */
 size_t convertIntArray2ByteArray_fast_dynamic(unsigned char* timeStepType, unsigned char resiBitLength, size_t nbEle, unsigned char **bytes)
 {
-	size_t i = 0, j = 0, k = 0; 
+	size_t i = 0, j = 0, k = 0;
 	int value;
 	DynamicByteArray* dba;
 	new_DBA(&dba, 1024);
@@ -415,14 +415,14 @@ size_t convertIntArray2ByteArray_fast_dynamic(unsigned char* timeStepType, unsig
 }
 
 /**
- * 
+ *
  * @param timeStepType is the resiMidBits
  * @param resiBitLength is the length of resiMidBits for each element, (the number of resiBitLength == the # of unpredictable elements
  * @return
  */
 size_t convertIntArray2ByteArray_fast_dynamic2(unsigned char* timeStepType, unsigned char* resiBitLength, size_t resiBitLengthLength, unsigned char **bytes)
 {
-	size_t i = 0, j = 0, k = 0; 
+	size_t i = 0, j = 0, k = 0;
 	int value;
 	DynamicByteArray* dba;
 	new_DBA(&dba, 1024);
@@ -467,14 +467,14 @@ int computeBitNumRequired(size_t dataLength)
 		return 32 - numberOfLeadingZeros_Int(dataLength);
 	else
 		return 64 - numberOfLeadingZeros_Long(dataLength);
-		
+
 }
 
 void decompressBitArraybySimpleLZ77(int** result, unsigned char* bytes, size_t bytesLength, size_t totalLength, int validLength)
 {
 	size_t pairLength = (bytesLength*8)/(validLength+1);
 	size_t tmpLength = pairLength*2;
-	int tmpResult[tmpLength];
+	int* tmpResult = (int*) malloc(tmpLength * sizeof(int));
 	size_t i, j, k = 0;
 	for(i = 0;i<tmpLength;i+=2)
 	{
@@ -484,13 +484,13 @@ void decompressBitArraybySimpleLZ77(int** result, unsigned char* bytes, size_t b
 		unsigned char curByte = bytes[outIndex];
 		tmpResult[i] = (curByte >> (8-1-innerIndex)) & 0x01;
 		k++;
-		
+
 		int numResult = extractBytes(bytes, k, validLength);
-		
+
 		tmpResult[i+1] = numResult;
 		k = k + validLength;
 	}
-	
+
 	*result = (int*)malloc(sizeof(int)*totalLength);
 	k = 0;
 	for(i = 0;i<tmpLength;i=i+2)
@@ -500,4 +500,5 @@ void decompressBitArraybySimpleLZ77(int** result, unsigned char* bytes, size_t b
 		for(j = 0;j<num;j++)
 			(*result)[k++] = state;
 	}
+	free(tmpResult);
 }

--- a/sz/src/rwf.c
+++ b/sz/src/rwf.c
@@ -16,81 +16,95 @@ void checkfilesizec_(char *srcFilePath, int *len, size_t *filesize)
 {
 	int i;
 	int status;
-	char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
 	for(i=0;i<*len;i++)
 		s[i]=srcFilePath[i];
 	s[*len]='\0';
 	*filesize = checkFileSize(s, &status);
+	free(s);
 }
 
 void readbytefile_(char *srcFilePath, int *len, unsigned char *bytes, size_t *byteLength)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=srcFilePath[i];
     s[*len]='\0';
     unsigned char *tmp_bytes = readByteData(s, byteLength, &ierr);
     memcpy(bytes, tmp_bytes, *byteLength);
     free(tmp_bytes);
+    free(s);
 }
 
 void readdoublefile_(char *srcFilePath, int *len, double *data, size_t *nbEle)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=srcFilePath[i];
     s[*len]='\0';
 	double *tmp_data = readDoubleData(s, nbEle, &ierr);
 	memcpy(data, tmp_data, *nbEle);
 	free(tmp_data);
+	free(s);
 }
 
 void readfloatfile_(char *srcFilePath, int *len, float *data, size_t *nbEle)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=srcFilePath[i];
     s[*len]='\0';
 	float *tmp_data = readFloatData(s, nbEle, &ierr);
 	memcpy(data, tmp_data, *nbEle);
 	free(tmp_data);
+	free(s);
 }
 
 void writebytefile_(unsigned char *bytes, size_t *byteLength, char *tgtFilePath, int *len)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=tgtFilePath[i];
     s[*len]='\0';
 	writeByteData(bytes, *byteLength, s, &ierr);
+	free(s);
 }
 
 void writedoublefile_(double *data, size_t *nbEle, char *tgtFilePath, int *len)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=tgtFilePath[i];
     s[*len]='\0';
 	writeDoubleData(data, *nbEle, s, &ierr);
+	free(s);
 }
 
 void writefloatfile_(float *data, size_t *nbEle, char *tgtFilePath, int *len)
 {
 	size_t i;
 	int ierr;
-    char s[*len+1];
+	/*char s[*len+1];*/
+	char* s = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s[i]=tgtFilePath[i];
     s[*len]='\0';
 	writeFloatData(data, *nbEle, s, &ierr);
+	free(s);
 }

--- a/sz/src/sz.c
+++ b/sz/src/sz.c
@@ -180,10 +180,10 @@ int filterDimension(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, size_
 		{
 			c[1]= 0;
 			dimensionCorrected = 1;
-		}	
+		}
 		if(r1==1) //remove this dimension
 		{
-			c[0] = c[1]; 
+			c[0] = c[1];
 			c[1] = c[2];
 			dimensionCorrected = 1;
 		}
@@ -194,7 +194,7 @@ int filterDimension(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, size_
 		{
 			c[2] = 0;
 			dimensionCorrected = 1;
-		}	
+		}
 		if(r2==1)
 		{
 			c[1] = c[2];
@@ -276,9 +276,9 @@ int filterDimension(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, size_
 			dimensionCorrected = 1;
 		}
 	}
-	
+
 	return dimensionCorrected;
-	
+
 }
 
 /*-------------------------------------------------------------------------*/

--- a/sz/src/sz_double.c
+++ b/sz/src/sz_double.c
@@ -1649,7 +1649,8 @@ size_t dataLength, double realPrecision, double valueRangeSize, double medianVal
 	uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
 	const int shift = 52-bits;
 	uint64_t expoIndex, mantiIndex;
-	uint16_t* tables[range+1];
+	/* uint16_t* tables[range+1]; */
+	uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
 	for(int i=0; i<=range; i++){
 		tables[i] = levelTable.subTables[i].table;
 	}
@@ -1713,6 +1714,7 @@ size_t dataLength, double realPrecision, double valueRangeSize, double medianVal
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 
@@ -1794,7 +1796,8 @@ TightDataPointStorageD* SZ_compress_double_2D_MDQ_MSST19(double *oriData, size_t
     uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
     const int shift = 52-bits;
     uint64_t expoIndex, mantiIndex;
-    uint16_t* tables[range+1];
+    /* uint16_t* tables[range+1]; */
+    uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
     for(int i=0; i<=range; i++){
         tables[i] = levelTable.subTables[i].table;
     }
@@ -1986,6 +1989,7 @@ TightDataPointStorageD* SZ_compress_double_2D_MDQ_MSST19(double *oriData, size_t
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 
@@ -2063,7 +2067,8 @@ TightDataPointStorageD* SZ_compress_double_3D_MDQ_MSST19(double *oriData, size_t
     uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
     const int shift = 52-bits;
     uint64_t expoIndex, mantiIndex;
-    uint16_t* tables[range+1];
+    /* uint16_t* tables[range+1]; */
+    uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
     for(int i=0; i<=range; i++){
         tables[i] = levelTable.subTables[i].table;
     }
@@ -2439,6 +2444,7 @@ TightDataPointStorageD* SZ_compress_double_3D_MDQ_MSST19(double *oriData, size_t
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 void SZ_compress_args_double_withinRange(unsigned char** newByteData, double *oriData, size_t dataLength, size_t *outSize)

--- a/sz/src/sz_double_pwr.c
+++ b/sz/src/sz_double_pwr.c
@@ -715,7 +715,8 @@ size_t dataLength, size_t *outSize, double min, double max)
 		size_t totalByteLength = 3 + exe_params->SZ_SIZE_TYPE + 1 + doubleSize*dataLength;
 		*newByteData = (unsigned char*)malloc(totalByteLength);
 
-		unsigned char dsLengthBytes[exe_params->SZ_SIZE_TYPE];
+		/* unsigned char dsLengthBytes[exe_params->SZ_SIZE_TYPE]; */
+		unsigned char* dsLengthBytes = (unsigned char*) malloc((exe_params->SZ_SIZE_TYPE) * sizeof(unsigned char));
 		intToBytes_bigEndian(dsLengthBytes, dataLength);//4
 		for (i = 0; i < 3; i++)//3
 			(*newByteData)[k++] = versionNumber[i];
@@ -741,6 +742,7 @@ size_t dataLength, size_t *outSize, double min, double max)
 				doubleToBytes(p, oriData[i]);
 		}
 		*outSize = totalByteLength;
+		free(dsLengthBytes);
 	}
 
 	free(pwrErrBound);

--- a/sz/src/sz_float.c
+++ b/sz/src/sz_float.c
@@ -1923,7 +1923,8 @@ size_t dataLength, double realPrecision, float valueRangeSize, float medianValue
 	uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
 	const int shift = 52-bits;
 	uint64_t expoIndex, mantiIndex;
-	uint16_t* tables[range+1];
+	/* uint16_t* tables[range+1]; */
+    uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
 	for(int i=0; i<=range; i++){
 		tables[i] = levelTable.subTables[i].table;
 	}
@@ -1987,6 +1988,7 @@ size_t dataLength, double realPrecision, float valueRangeSize, float medianValue
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 
@@ -2068,7 +2070,8 @@ TightDataPointStorageF* SZ_compress_float_2D_MDQ_MSST19(float *oriData, size_t r
     uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
     const int shift = 52-bits;
     uint64_t expoIndex, mantiIndex;
-    uint16_t* tables[range+1];
+    /* uint16_t* tables[range+1]; */
+    uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
     for(int i=0; i<=range; i++){
         tables[i] = levelTable.subTables[i].table;
     }
@@ -2260,6 +2263,7 @@ TightDataPointStorageF* SZ_compress_float_2D_MDQ_MSST19(float *oriData, size_t r
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 
@@ -2337,7 +2341,8 @@ TightDataPointStorageF* SZ_compress_float_3D_MDQ_MSST19(float *oriData, size_t r
     uint64_t* const buffer = (uint64_t*)&predRelErrRatio;
     const int shift = 52-bits;
     uint64_t expoIndex, mantiIndex;
-    uint16_t* tables[range+1];
+    /* uint16_t* tables[range+1]; */
+    uint16_t** tables =  (uint16_t**) malloc((range + 1) * sizeof(uint16_t*));
     for(int i=0; i<=range; i++){
         tables[i] = levelTable.subTables[i].table;
     }
@@ -2715,6 +2720,7 @@ TightDataPointStorageF* SZ_compress_float_3D_MDQ_MSST19(float *oriData, size_t r
 	free(exactMidByteArray); //exactMidByteArray->array has been released in free_TightDataPointStorageF(tdps);
 	free(precisionTable);
 	freeTopLevelTableWideInterval(&levelTable);
+	free(tables);
 	return tdps;
 }
 

--- a/sz/src/sz_float_pwr.c
+++ b/sz/src/sz_float_pwr.c
@@ -719,7 +719,8 @@ size_t dataLength, size_t *outSize, float min, float max)
 		size_t totalByteLength = 3 + exe_params->SZ_SIZE_TYPE + 1 + floatSize*dataLength;
 		*newByteData = (unsigned char*)malloc(totalByteLength);
 
-		unsigned char dsLengthBytes[exe_params->SZ_SIZE_TYPE];
+		/* unsigned char dsLengthBytes[exe_params->SZ_SIZE_TYPE]; */
+		unsigned char* dsLengthBytes = (unsigned char*) malloc((exe_params->SZ_SIZE_TYPE) * sizeof(unsigned char));
 		intToBytes_bigEndian(dsLengthBytes, dataLength);//4
 		for (i = 0; i < 3; i++)//3
 			(*newByteData)[k++] = versionNumber[i];
@@ -745,6 +746,7 @@ size_t dataLength, size_t *outSize, float min, float max)
 				floatToBytes(p, oriData[i]);
 		}
 		*outSize = totalByteLength;
+		free(dsLengthBytes);
 	}
 
 	free(pwrErrBound);

--- a/sz/src/sz_omp.c
+++ b/sz/src/sz_omp.c
@@ -160,7 +160,10 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	HuffmanTree* huffmanTree = createHuffmanTree(stateNum);
 
 	int num_yz = num_y * num_z;
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -256,7 +259,10 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	for(int t=1; t<thread_num; t++){
 		unpred_offset[t] = unpredictable_count[t-1] + unpred_offset[t-1];
 	}
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		float * unpredictable_data = result_unpredictable_data + id * unpred_data_max_size;
@@ -272,7 +278,10 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 
 	size_t * block_pos = (size_t *) result_pos;
 	result_pos += num_blocks * sizeof(size_t);
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -305,7 +314,10 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	for(int t=1; t<thread_num; t++){
 		block_offset[t] = block_pos[t-1] + block_offset[t-1];
 	}
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		memcpy(result_pos + block_offset[id], encoding_buffer + t * max_num_block_elements * sizeof(int), block_pos[t]);
@@ -486,7 +498,10 @@ void decompressDataSeries_float_3D_openmp(float** data, size_t r1, size_t r2, si
 	printf("Read data info elapsed time: %.4f\n", elapsed_time);
 #endif
 	elapsed_time = -sz_wtime();
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -508,7 +523,10 @@ void decompressDataSeries_float_3D_openmp(float** data, size_t r1, size_t r2, si
 #endif
 	elapsed_time = -sz_wtime();
 
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -657,7 +675,10 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 	HuffmanTree* huffmanTree = createHuffmanTree(stateNum);
 
 	int num_yz = num_y * num_z;
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -744,7 +765,10 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 		unpred_offset[t] = unpredictable_count[t-1] + unpred_offset[t-1];
 	}
 
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		double * unpredictable_data = result_unpredictable_data + id * unpred_data_max_size;
@@ -760,7 +784,10 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 
 	size_t * block_pos = (size_t *) result_pos;
 	result_pos += num_blocks * sizeof(size_t);
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -793,7 +820,10 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 	for(int t=1; t<thread_num; t++){
 		block_offset[t] = block_pos[t-1] + block_offset[t-1];
 	}
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		memcpy(result_pos + block_offset[id], encoding_buffer + t * max_num_block_elements * sizeof(int), block_pos[t]);
@@ -953,7 +983,10 @@ void decompressDataSeries_double_3D_openmp(double** data, size_t r1, size_t r2, 
 	printf("Read data info elapsed time: %.4f\n", elapsed_time);
 #endif
 	elapsed_time = -sz_wtime();
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -975,7 +1008,10 @@ void decompressDataSeries_double_3D_openmp(double** data, size_t r1, size_t r2, 
 #endif
 	elapsed_time = -sz_wtime();
 
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int i = id/(num_yz);
@@ -1016,7 +1052,10 @@ void Huffman_init_openmp(HuffmanTree* huffmanTree, int *s, size_t length, int th
 	// memset(freq, 0, thread_num*huffmanTree->allNodes*sizeof(size_t));
 	size_t block_size = (length - 1)/ thread_num + 1;
 	size_t block_residue = length - (thread_num - 1) * block_size;
+	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+#ifndef _MSC_VER
 	#pragma omp parallel for
+#endif
 	for(int t=0; t<thread_num; t++){
 		int id = sz_get_thread_num();
 		int * s_pos = s + id * block_size;

--- a/sz/src/sz_omp.c
+++ b/sz/src/sz_omp.c
@@ -160,7 +160,7 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	HuffmanTree* huffmanTree = createHuffmanTree(stateNum);
 
 	int num_yz = num_y * num_z;
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -259,7 +259,7 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	for(int t=1; t<thread_num; t++){
 		unpred_offset[t] = unpredictable_count[t-1] + unpred_offset[t-1];
 	}
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -278,7 +278,7 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 
 	size_t * block_pos = (size_t *) result_pos;
 	result_pos += num_blocks * sizeof(size_t);
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -314,7 +314,7 @@ unsigned char * SZ_compress_float_3D_MDQ_openmp(float *oriData, size_t r1, size_
 	for(int t=1; t<thread_num; t++){
 		block_offset[t] = block_pos[t-1] + block_offset[t-1];
 	}
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -498,7 +498,7 @@ void decompressDataSeries_float_3D_openmp(float** data, size_t r1, size_t r2, si
 	printf("Read data info elapsed time: %.4f\n", elapsed_time);
 #endif
 	elapsed_time = -sz_wtime();
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -523,7 +523,7 @@ void decompressDataSeries_float_3D_openmp(float** data, size_t r1, size_t r2, si
 #endif
 	elapsed_time = -sz_wtime();
 
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -675,7 +675,7 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 	HuffmanTree* huffmanTree = createHuffmanTree(stateNum);
 
 	int num_yz = num_y * num_z;
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -765,7 +765,7 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 		unpred_offset[t] = unpredictable_count[t-1] + unpred_offset[t-1];
 	}
 
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -784,7 +784,7 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 
 	size_t * block_pos = (size_t *) result_pos;
 	result_pos += num_blocks * sizeof(size_t);
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -820,7 +820,7 @@ unsigned char * SZ_compress_double_3D_MDQ_openmp(double *oriData, size_t r1, siz
 	for(int t=1; t<thread_num; t++){
 		block_offset[t] = block_pos[t-1] + block_offset[t-1];
 	}
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -983,7 +983,7 @@ void decompressDataSeries_double_3D_openmp(double** data, size_t r1, size_t r2, 
 	printf("Read data info elapsed time: %.4f\n", elapsed_time);
 #endif
 	elapsed_time = -sz_wtime();
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -1008,7 +1008,7 @@ void decompressDataSeries_double_3D_openmp(double** data, size_t r1, size_t r2, 
 #endif
 	elapsed_time = -sz_wtime();
 
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif
@@ -1052,7 +1052,7 @@ void Huffman_init_openmp(HuffmanTree* huffmanTree, int *s, size_t length, int th
 	// memset(freq, 0, thread_num*huffmanTree->allNodes*sizeof(size_t));
 	size_t block_size = (length - 1)/ thread_num + 1;
 	size_t block_residue = length - (thread_num - 1) * block_size;
-	// Visual Studio compilers do not like the definition of the variables inside de parallel for loop
+	// Visual Studio compilers do not like the definition of the variables inside the parallel for loop
 #ifndef _MSC_VER
 	#pragma omp parallel for
 #endif

--- a/sz/src/szf.c
+++ b/sz/src/szf.c
@@ -18,12 +18,14 @@
 void sz_init_c_(char *configFile,int *len,int *ierr)
 {
     int i;
-    char s2[*len+1];
+    /*char s2[*len+1];*/
+    char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=configFile[i];
     s2[*len]='\0';
  //   printf("sconfigFile=%s\n",configFile);
     *ierr = SZ_Init(s2);
+    free(s2);
 }
 
 void sz_finalize_c_()
@@ -32,17 +34,17 @@ void sz_finalize_c_()
 }
 
 //compress with config (without args in function)
-void sz_compress_d1_float_(float* data, unsigned char *bytes, size_t *outSize, size_t *r1)	
+void sz_compress_d1_float_(float* data, unsigned char *bytes, size_t *outSize, size_t *r1)
 {
 	unsigned char *tmp_bytes = SZ_compress(SZ_FLOAT, data, outSize, 0, 0, 0, 0, *r1);
-	memcpy(bytes, tmp_bytes, *outSize);	
+	memcpy(bytes, tmp_bytes, *outSize);
 	free(tmp_bytes);
 }
 
-void sz_compress_d1_float_rev_(float* data, float *reservedValue, unsigned char *bytes, size_t *outSize, size_t *r1)	
+void sz_compress_d1_float_rev_(float* data, float *reservedValue, unsigned char *bytes, size_t *outSize, size_t *r1)
 {
 	unsigned char *tmp_bytes = SZ_compress_rev(SZ_FLOAT, data, reservedValue, outSize, 0, 0, 0, 0, *r1);
-	memcpy(bytes, tmp_bytes, *outSize);	
+	memcpy(bytes, tmp_bytes, *outSize);
 	free(tmp_bytes);
 }
 
@@ -407,101 +409,123 @@ void sz_decompress_d5_double_(unsigned char *bytes, size_t *byteLength, double *
 void sz_batchaddvar_d1_float_(int var_id, char* varName, int *len, float* data, int *errBoundMode, float *absErrBound, float *relBoundRatio, size_t *r1)
 {
 	int i;
-    char s2[*len+1];
+    /*char s2[*len+1];*/
+    char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_FLOAT, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, 0, 0, *r1);
+	free(s2);
 }
 void sz_batchaddvar_d2_float_(int var_id, char* varName, int *len, float* data, int *errBoundMode, float *absErrBound, float *relBoundRatio, size_t *r1, size_t *r2)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_FLOAT, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, 0, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d3_float_(int var_id, char* varName, int *len, float* data, int *errBoundMode, float *absErrBound, float *relBoundRatio, size_t *r1, size_t *r2, size_t *r3)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_FLOAT, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d4_float_(int var_id, char* varName, int *len, float* data, int *errBoundMode, float *absErrBound, float *relBoundRatio, size_t *r1, size_t *r2, size_t *r3, size_t *r4)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_FLOAT, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, *r4, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d5_float_(int var_id, char* varName, int *len, float* data, int *errBoundMode, float *absErrBound, float *relBoundRatio, size_t *r1, size_t *r2, size_t *r3, size_t *r4, size_t *r5)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_FLOAT, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, *r5, *r4, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d1_double_(int var_id, char* varName, int *len, double* data, int *errBoundMode, double *absErrBound, double *relBoundRatio, size_t *r1)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_DOUBLE, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, 0, 0, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d2_double_(int var_id, char* varName, int *len, double* data, int *errBoundMode, double *absErrBound, double *relBoundRatio, size_t *r1, size_t *r2)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_DOUBLE, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, 0, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d3_double_(int var_id, char* varName, int *len, double* data, int *errBoundMode, double *absErrBound, double *relBoundRatio, size_t *r1, size_t *r2, size_t *r3)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_DOUBLE, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, 0, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d4_double_(int var_id, char* varName, int *len, double* data, int *errBoundMode, double *absErrBound, double *relBoundRatio, size_t *r1, size_t *r2, size_t *r3, size_t *r4)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_DOUBLE, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, 0, *r4, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchaddvar_d5_double_(int var_id, char* varName, int *len, double* data, int *errBoundMode, double *absErrBound, double *relBoundRatio, size_t *r1, size_t *r2, size_t *r3, size_t *r4, size_t *r5)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';		
+    s2[*len]='\0';
 	SZ_batchAddVar(var_id, s2, SZ_DOUBLE, data, *errBoundMode, *absErrBound, *relBoundRatio, 0.1, *r5, *r4, *r3, *r2, *r1);
+    free(s2);
 }
 void sz_batchdelvar_c_(char* varName, int *len, int *errState)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
     s2[*len]='\0';
 	*errState = SZ_batchDelVar(s2);
+	free(s2);
 }
 
 /*@deprecated*/
@@ -520,13 +544,15 @@ void sz_batch_decompress_c_(unsigned char* bytes, size_t *byteLength, int *ierr)
 void sz_getvardim_c_(char* varName, int *len, int *dim, size_t *r1, size_t *r2, size_t *r3, size_t *r4, size_t *r5)
 {
 	int i;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
     s2[*len]='\0';
-    
+
     SZ_getVarData(s2, r5, r4, r3, r2, r1);
     *dim = computeDimension(*r5, *r4, *r3, *r2, *r1);
+    free(s2);
 }
 
 void compute_total_batch_size_c_(size_t *totalSize)
@@ -538,29 +564,33 @@ void sz_getvardata_float_(char* varName, int *len, float* data)
 {
 	int i;
 	size_t r1, r2, r3, r4, r5;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';	
-	
+    s2[*len]='\0';
+
 	float* tmp_data = (float*)SZ_getVarData(s2, &r5, &r4, &r3, &r2, &r1);
 	int size = computeDataLength(r5, r4, r3, r2, r1);
 	memcpy(data, tmp_data, size*sizeof(float));
-	free(tmp_data);	
+	free(tmp_data);
+	free(s2);
 }
 void sz_getvardata_double_(char* varName, int *len, double* data)
 {
 	int i;
 	size_t r1, r2, r3, r4, r5;
-    char s2[*len+1];
+	/*char s2[*len+1];*/
+	char* s2 = (char*) malloc((*len + 1) * sizeof(char));
     for(i=0;i<*len;i++)
         s2[i]=varName[i];
-    s2[*len]='\0';	
-    
+    s2[*len]='\0';
+
 	double* tmp_data = (double*)SZ_getVarData(s2, &r5, &r4, &r3, &r2, &r1);
 	int size = computeDataLength(r5, r4, r3, r2, r1);
 	memcpy(data, tmp_data, size*sizeof(double));
 	//free(tmp_data);
+	free(s2);
 }
 
 void sz_freevarset_c_(int *mode)


### PR DESCRIPTION
- Make minimal modifications to source code to get SZ and its HDF5 filter compile with Visual Studio compilers
- Reverts SHA1 ID: https://github.com/szcompressor/SZ/commit/8cb1cd1e0f8e763495be2c89e357c2fd6e0d071e (issue #100 )

Despite many compilation warnings while compiling SZ, the SZ HDF5 filter seems to work under windows (https://github.com/silx-kit/hdf5plugin/issues/195#issuecomment-1310691898)

OpenMP is disabled when using Microsoft Compilers. Their OpenMP implementation does not appreciate variables being defined inside parallel for loops. If this PR is accepted, I can try to go further and put the variable definitions outside the loop. 

