### PR TITLE
Resolve Clang 15 Errors: Remove unused H5Z debug functions

### DIFF
--- a/hdf5-filter/H5Z-SZ/src/H5Z_SZ.c
+++ b/hdf5-filter/H5Z-SZ/src/H5Z_SZ.c
@@ -13,27 +13,6 @@
 #include "H5Z_SZ.h"
 #include "H5PLextern.h"
 
-struct timeval startTime;
-struct timeval endTime;  /* Start and end times */
-struct timeval costStart; /*only used for recording the cost*/
-double totalCost = 0;
-
-void cost_start()
-{
-        totalCost = 0;
-        gettimeofday(&costStart, NULL);
-}
-
-void cost_end()
-{
-        double elapsed;
-        struct timeval costEnd;
-        gettimeofday(&costEnd, NULL);
-        elapsed = ((costEnd.tv_sec*1000000+costEnd.tv_usec)-(costStart.tv_sec*1000000+costStart.tv_usec))/1000000.0;
-        totalCost += elapsed;
-}
-
-
 //sz_params* conf_params = NULL;
 int load_conffile_flag = 1; //set to load configuration file at the beginning by user
 
@@ -468,7 +447,6 @@ static size_t H5Z_filter_sz(unsigned int flags, size_t cd_nelmts, const unsigned
 
 	if (flags & H5Z_FLAG_REVERSE) 
 	{ 
-		//cost_start();
 		/* decompress data */
 		if(dataType == SZ_FLOAT)//==0
 		{
@@ -554,15 +532,12 @@ static size_t H5Z_filter_sz(unsigned int flags, size_t cd_nelmts, const unsigned
 			printf("Decompression error: unknown data type: %d\n", dataType);
 			exit(0);
 		}
-		//cost_end();
-		//printf("decompression time = %lf, decompression rate = %lf\n", totalCost, 1.0*nbEle*sizeof(float)/totalCost);
 	}
 	else //compression
 	{
 		size_t outSize = 0;
 	
 		//printf("r5=%d, r4=%d, r3=%d, r2=%d, r1=%d, dataType=%d\n", r5, r4, r3, r2, r1, dataType);
-		//cost_start();
 		if(dataType == SZ_FLOAT)//==0
 		{
 			float* data = (float*)(*buf);
@@ -732,8 +707,6 @@ static size_t H5Z_filter_sz(unsigned int flags, size_t cd_nelmts, const unsigned
 			printf("Compression error: unknown data type: %d\n", dataType);
 			exit(0);
 		}
-		//cost_end();
-		//printf("compression time = %lf, compression rate = %lf\n", totalCost, 1.0*nbEle*sizeof(float)/totalCost);
 	}
 	
 	//H5Z_SZ_Finalize();


### PR DESCRIPTION
These debug cost functions' use of `gettimeofday()` fails to compile with newer clang versions (>15). This is because clang stopped supporting certain implicit function definitions [see more](https://github.com/llvm/llvm-project/commit/7d644e1215b376ec5e915df9ea2eeb56e2d94626).

These functions have been commented out in the actual code, so removing them restores Clang 15 compatibility without side effects.