### PR TITLE
CMake build under windows using NMake

### DIFF
--- a/sz/CMakeLists.txt
+++ b/sz/CMakeLists.txt
@@ -92,11 +92,18 @@ set_target_properties (SZ PROPERTIES
     OUTPUT_NAME_RELWITHDEBINFO ${LIB_RELEASE_NAME}
   )
 
-target_link_libraries (SZ PUBLIC ${ZLIB_dep} ${ZSTD_dep} m)
+if (WIN32 AND NOT MINGW)
+    target_link_libraries (SZ PUBLIC ${ZLIB_dep} ${ZSTD_dep})
+else ()
+    target_link_libraries (SZ PUBLIC ${ZLIB_dep} ${ZSTD_dep} m)
+endif ()
 
-target_compile_options(SZ
-	PRIVATE $<$<CONFIG:Debug>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
-	)
+if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GCC detected, adding compile flags")
+    target_compile_options(SZ
+        PRIVATE $<$<CONFIG:Debug>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
+    )
+endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(BUILD_OPENMP)
   target_link_libraries(SZ PRIVATE OpenMP::OpenMP_C)

--- a/zlib/CMakeLists.txt
+++ b/zlib/CMakeLists.txt
@@ -4,6 +4,10 @@ else ()
   set (BUILD_EXT_LIBS_TYPE "STATIC")
 endif ()
 
+if (WIN32 AND NOT MINGW)
+  set (BUILD_EXT_LIBS_TYPE "STATIC")
+endif ()
+
 add_library(ZLIB ${BUILD_EXT_LIBS_TYPE} 
   ./gzclose.c
   ./uncompr.c

--- a/zstd/CMakeLists.txt
+++ b/zstd/CMakeLists.txt
@@ -4,6 +4,10 @@ else ()
   set (BUILD_EXT_LIBS_TYPE "STATIC")
 endif ()
 
+if (WIN32 AND NOT MINGW)
+  set (BUILD_EXT_LIBS_TYPE "STATIC")
+endif ()
+
 add_library(zstd ${BUILD_EXT_LIBS_TYPE} 
   ./common/entropy_common.c
   ./common/pool.c


### PR DESCRIPTION
Addresses #91

With these changes, the following instructions build SZ under windows with native MSVC compiler

```
mkdir build
cd build
cmake .. -G"NMake Makefiles"
nmake
```